### PR TITLE
Add Thai language

### DIFF
--- a/joker_names.lua
+++ b/joker_names.lua
@@ -196,14 +196,25 @@ end
 if RequiredScript == "lib/managers/menumanager" then
 
   Hooks:Add("LocalizationManagerPostInit", "LocalizationManagerPostInitJokerNames", function(loc)
-    loc:load_localization_file(JokerNames.mod_path .. "loc/english.txt")
-    for _, filename in pairs(file.GetFiles(JokerNames.mod_path .. "loc/") or {}) do
-      local str = filename:match("^(.*).txt$")
-      if str and Idstring(str) and Idstring(str):key() == SystemInfo:language():key() then
-        loc:load_localization_file(JokerNames.mod_path .. "loc/" .. filename)
-        break
-      end
-    end
+	local custom_language
+	for _, mod in pairs(BLT and BLT.Mods:Mods() or {}) do
+		if mod:GetName() == "PAYDAY 2 THAI LANGUAGE Mod" and mod:IsEnabled() then
+			custom_language = "thai"
+			break
+		end			
+	end
+	if custom_language then
+		loc:load_localization_file(JokerNames.mod_path .. "loc/" .. custom_language ..".txt")
+    else
+		for _, filename in pairs(file.GetFiles(JokerNames.mod_path .. "loc/") or {}) do
+			local str = filename:match("^(.*).txt$")
+			if str and Idstring(str) and Idstring(str):key() == SystemInfo:language():key() then
+				loc:load_localization_file(JokerNames.mod_path .. "loc/" .. filename)
+				break
+			end
+		end
+	end
+	loc:load_localization_file(JokerNames.mod_path .. "loc/english.txt", false)
     JokerNames:create_localized_name_styles(loc)
   end)
 

--- a/joker_names.lua
+++ b/joker_names.lua
@@ -196,6 +196,7 @@ end
 if RequiredScript == "lib/managers/menumanager" then
 
   Hooks:Add("LocalizationManagerPostInit", "LocalizationManagerPostInitJokerNames", function(loc)
+	loc:load_localization_file(JokerNames.mod_path .. "loc/english.txt")
 	local custom_language
 	for _, mod in pairs(BLT and BLT.Mods:Mods() or {}) do
 		if mod:GetName() == "PAYDAY 2 THAI LANGUAGE Mod" and mod:IsEnabled() then
@@ -214,7 +215,7 @@ if RequiredScript == "lib/managers/menumanager" then
 			end
 		end
 	end
-	loc:load_localization_file(JokerNames.mod_path .. "loc/english.txt", false)
+	
     JokerNames:create_localized_name_styles(loc)
   end)
 

--- a/loc/thai.txt
+++ b/loc/thai.txt
@@ -1,0 +1,21 @@
+{
+  "JokerNames_menu_main_name" : "ชื่อเฉพาะจากม๊อท'ผู้บังคับการ'",
+  "JokerNames_menu_main_desc" : "Keepers Joker Names: กำหนดชื่อตำรวจที่ถูกกล่อมให้เป็นพวก (โจ๊กเกอร์) ด้วยตนเอง",
+  "JokerNames_menu_use_custom_names" : "ใช้ชื่อที่กำหนดเอง",
+  "JokerNames_menu_use_custom_names_desc" : "Use custom names: ใช้ชื่อที่กำหนดขึ้นเองแทนที่ชื่อที่ถูกตั้งจาก mod 'ผู้บังคับการ'",
+  "JokerNames_menu_information" : "ข้อมูล",
+  "JokerNames_menu_information_text" : "ไฟล์ชื่อ \"custom_joker_names.txt\" ถูกสร้างขึ้นและถูกเก็บไว้ใน \"PAYDAY 2/mods/saves\" เพื่อเป็นตัวอย่างการตั้งชื่อ\nสามารถแก้ไขเพื่อเพิ่มชื่อที่กำหนดขึ้นเอง",
+  "JokerNames_menu_name_style" : "รูปแบบชื่อ",
+  "JokerNames_menu_name_style_desc" : "Name format: รูปแบบของชื่อโจ๊กเกอร์"
+  "JokerNames_menu_name_style_name" : "ชื่อ",
+  "JokerNames_menu_name_style_keepers_name" : "ชื่อของโจ๊กเกอร์",
+  "JokerNames_menu_name_style_keepers_type" : "ชนิด",
+  "JokerNames_menu_name_style_custom" : "กำหนดเอง",
+  "JokerNames_menu_custom_name_style" : "รูปแบบชื่อที่กำหนดเอง",
+  "JokerNames_menu_custom_name_style_desc" : "Custom name format: สร้างรูปแบบชื่อในแบบของคุณเอง\n%N = ชื่อ, %K = ชื่อเจ้าของ, %T = ประเภทหน่วยรบ",
+  "JokerNames_menu_force_names" : "แทนที่ชื่อ",
+  "JokerNames_menu_force_names_desc" : "Override names: แทนที่ชื่อโจ๊กเกอร์ขึ้นอยู่กับการตั้งค่า",
+  "JokerNames_menu_force_names_never" : "ไม่แทนที่",
+  "JokerNames_menu_force_names_empty" : "แทนที่หากไม่ได้กำหนด",
+  "JokerNames_menu_force_names_always" : "แทนที่เสมอ"
+}


### PR DESCRIPTION
Hi again. Sorry for more pull requests. Currently I'm trying to translate all mods I'm using into my native language (Thai language) and I'll post make a sheet to list all mods I've translated so my fellow Thai people can download those mods and understand how this/that mod works. 
```
- Added Thai language
- Triggered Thai language by checking a mod's name. (Using array maybe better but this should do for now)
```
Sorry if this a bit bothering you and thanks for making such a cool mod.